### PR TITLE
Make CLAUDE.md Git conventions branch-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,9 @@ practical workflow is:
 
 ### Git conventions
 
-- Active development branch for this work: `claude/claude-md-docs-5ow5mq`. Create it locally if
-  missing; do not push to other branches without explicit permission.
+- Develop on the branch selected by the user or the environment for the current task; create it
+  locally if it doesn't exist. Do not push to `main` or other branches without explicit
+  permission.
 - Always push with `git push -u origin <branch-name>`; retry network failures with exponential
   backoff.
 - **Do not open a pull request unless explicitly asked.**


### PR DESCRIPTION
## Summary

Follow-up to #4 addressing Codex review feedback that landed after that PR was merged.

The `Git conventions` section of `CLAUDE.md` hard-coded the task-specific branch name `claude/claude-md-docs-5ow5mq`. Because `CLAUDE.md` is root guidance meant to be reused by future assistants, this would have caused later tasks to create or push to that stale docs branch regardless of the branch actually checked out.

This PR makes the guidance generic: develop on the branch selected by the user or environment, and don't push to `main` or other branches without explicit permission.

## Changes

- `CLAUDE.md`: replace the hard-coded branch reference with branch-agnostic guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018Xz6LoUz7E8AZJaVTpgUHF)_